### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/gpu-screen-recorder-gtk.spec
+++ b/gpu-screen-recorder-gtk.spec
@@ -14,7 +14,6 @@ Epoch:          2
 BuildRequires:  gcc
 BuildRequires:  (gcc-g++ or gcc-c++)
 BuildRequires:  meson
-BuildRequires:  cmake
 BuildRequires:  pkgconfig(gtk+-3.0)
 BuildRequires:  (pkgconfig(ayatana-appindicator3-0.1) or libayatana-appindicator-gtk3-devel or libayatana-appindicator3-dev)
 BuildRequires:  desktop-file-utils

--- a/gpu-screen-recorder-notification.spec
+++ b/gpu-screen-recorder-notification.spec
@@ -11,12 +11,10 @@ URL:            https://git.dec05eba.com/%{name}/about
 BuildRequires:  gcc
 BuildRequires:  (gcc-g++ or gcc-c++)
 BuildRequires:  meson
-BuildRequires:  cmake
 BuildRequires:  pkgconfig(x11)
 BuildRequires:  pkgconfig(xext)
 BuildRequires:  pkgconfig(xrandr)
 BuildRequires:  pkgconfig(xrender)
-BuildRequires:  desktop-file-utils
 BuildRequires:  pkgconfig(libglvnd)
 Requires:       (google-noto-sans-fonts or noto-sans)
 

--- a/gpu-screen-recorder-ui.spec
+++ b/gpu-screen-recorder-ui.spec
@@ -11,21 +11,16 @@ URL:            https://git.dec05eba.com/%{name}/about
 BuildRequires:  gcc
 BuildRequires:  (gcc-g++ or gcc-c++)
 BuildRequires:  meson
-BuildRequires:  cmake
 BuildRequires:  pkgconfig(x11)
-BuildRequires:  pkgconfig(xdamage)
 BuildRequires:  pkgconfig(xcomposite)
 BuildRequires:  pkgconfig(xrandr)
 BuildRequires:  pkgconfig(xfixes)
 BuildRequires:  pkgconfig(xi)
 BuildRequires:  pkgconfig(xrender)
-BuildRequires:  pkgconfig(libevdev)
-BuildRequires:  pkgconfig(libudev)
-BuildRequires:  pkgconfig(libinput)
-BuildRequires:  pkgconfig(xkbcommon)
 BuildRequires:  pkgconfig(libglvnd)
-BuildRequires:  desktop-file-utils
+BuildRequires:  kernel-headers
 Requires:       gpu-screen-recorder
+Requires:       gpu-screen-recorder-notification
 Requires:       (google-noto-sans-fonts or noto-sans)
 
 %description

--- a/gpu-screen-recorder.spec
+++ b/gpu-screen-recorder.spec
@@ -16,7 +16,6 @@ Source:         https://dec05eba.com/snapshot/%{name}.git.%{snapshot}.tar.gz
 
 BuildRequires:  gcc
 BuildRequires:  (gcc-g++ or gcc-c++)
-BuildRequires:  cmake
 BuildRequires:  pkgconfig(libva)
 BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(libva-drm)


### PR DESCRIPTION
gpu-screen-recorder-ui no longer depends on libevdev, libudev, libinput and xkbcommon.
It instead depends on header files in /usr/include/linux and I believe kernel-headers
is the correct library for that, looking at the files it provides.
gpu-screen-recorder-ui also depends on gpu-screen-recorder-notification.