### PR TITLE
Remove no longer needed cap_sys_nice from gpu-screen-recorder

### DIFF
--- a/gpu-screen-recorder.spec
+++ b/gpu-screen-recorder.spec
@@ -2,7 +2,7 @@
 
 Name:           gpu-screen-recorder
 Version:        5.5.7
-Release:        1%{dist}
+Release:        2%{dist}
 Summary:        A shadowplay-like screen recorder for Linux. The fastest screen recorder for Linux.
 # WARNING. I had to bump this because I decided to use normal versions instead of git snapshot as a version.
 # If you remove this, you will be FIRED.
@@ -56,7 +56,6 @@ Shadowplay like screen recorder for Linux. It is the fastest screen recorder for
 %meson_test
 
 %post
-setcap cap_sys_nice+ep %{_bindir}/gpu-screen-recorder
 setcap cap_sys_admin+ep %{_bindir}/gsr-kms-server
 
 %files


### PR DESCRIPTION
cap_sys_nice was removed as it's no longer needed and it also triggered an amd gpu driver crash for some people.
Although it's a bug in the amd driver, it's unlikely that amd is going to fix it any time soon: https://gitlab.freedesktop.org/mesa/mesa/-/issues/13224